### PR TITLE
parse unterminated string literal as TokenKind::Invalid

### DIFF
--- a/boson/src/lexer/mod.rs
+++ b/boson/src/lexer/mod.rs
@@ -407,6 +407,9 @@ impl ProgramLexer {
 
                     break;
                 }
+                // If we have reached the end of the file, then the string literal is invalid.
+                EOF_BYTE => return TokenKind::Invalid,
+
                 _ => {
                     prev_char = self.current_char;
                     self.read_next();


### PR DESCRIPTION
I think this should fix the infinite hangs. Let me know if there's a better tokenkind to return here.
resolves: #11 